### PR TITLE
Removed useless voice playerDisconnect event listener

### DIFF
--- a/voice/server/index.js
+++ b/voice/server/index.js
@@ -46,12 +46,6 @@ alt.on("playerConnect", (player) => {
   changeVoiceChannel(defaultRange, player);
 });
 
-alt.on("playerDisconnect", (player, reason) => {
-  channelShort.removePlayer(player);
-  channelMedium.removePlayer(player);
-  channelLong.removePlayer(player);
-});
-
 alt.onClient("voice:rangeChanged", (player, args) => {
   let index = player.getMeta("voice:rangeIndex");
   index++;


### PR DESCRIPTION
In any case, the player is removed from the voice channel when disconnected from the server by the alt:V itself