### PR TITLE
Fix for imports

### DIFF
--- a/chat/server/index.js
+++ b/chat/server/index.js
@@ -1,5 +1,5 @@
 import * as alt from "alt-server";
-import { CHAT_MESSAGE_EVENT } from "../shared";
+import { CHAT_MESSAGE_EVENT } from "../shared/index.js";
 
 let cmdHandlers = {};
 let mutedPlayers = new Map();


### PR DESCRIPTION
This pull requests resolves "ERR_UNSUPPORTED_DIR_IMPORT".

```
2023-06-25 11:32:18 Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import '/opt/altv/resources/chat/shared' is not supported resolving ES modules imported from /opt/altv/resources/chat/server/index.js
2023-06-25 11:32:18     at new NodeError (node:internal/errors:400:5)
2023-06-25 11:32:18     at finalizeResolution (node:internal/modules/esm/resolve:319:17)
2023-06-25 11:32:18     at moduleResolve (node:internal/modules/esm/resolve:945:10)
2023-06-25 11:32:18     at defaultResolve (node:internal/modules/esm/resolve:1153:11)
2023-06-25 11:32:18     at nextResolve (node:internal/modules/esm/loader:163:28)
2023-06-25 11:32:18     at resolve (node:embedder_main_2:95:16)
2023-06-25 11:32:18     at nextResolve (node:internal/modules/esm/loader:163:28)
2023-06-25 11:32:18     at ESMLoader.resolve (node:internal/modules/esm/loader:842:30)
2023-06-25 11:32:18     at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
2023-06-25 11:32:18     at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:77:40) {
2023-06-25 11:32:18   code: 'ERR_UNSUPPORTED_DIR_IMPORT',
2023-06-25 11:32:18   url: 'file:///opt/altv/resources/chat/shared'
```

```
2023-06-25 11:32:18 [09:32:17] Loading resource chat
2023-06-25 11:32:18 [09:32:17][Error] Failed to load resource chat
```