### PR TITLE
fix(chat): Fix escapeString

### DIFF
--- a/chat/client/html/app.js
+++ b/chat/client/html/app.js
@@ -30,8 +30,6 @@ function colorify(text) {
   let m = null;
   let curPos = 0;
 
-  text = escapeString(text);
-
   do {
     m = /\{[A-Fa-f0-9]{3}\}|\{[A-Fa-f0-9]{6}\}/g.exec(text.substr(curPos));
 
@@ -180,7 +178,7 @@ function addString(text) {
   highlightChat();
 }
 
-alt.on("addString", (text) => addString(colorify(text)));
-alt.on("addMessage", (name, text) => addString("<b>" + name + ": </b>" + colorify(text)));
+alt.on("addString", (text) => addString(colorify(escapeString(text))));
+alt.on("addMessage", (name, text) => addString("<b>" + escapeString(name) + ": </b>" + colorify(escapeString(text))));
 alt.on("openChat", openChat);
 alt.on("closeChat", closeChat);

--- a/chat/client/html/app.js
+++ b/chat/client/html/app.js
@@ -18,7 +18,7 @@ function escapeString(str) {
   if (typeof str !== "string") return str;
 
   return str
-    .replace(/&/g, "&amp;")
+    //.replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")

--- a/freeroam-extended/client/html/app.js
+++ b/freeroam-extended/client/html/app.js
@@ -18,7 +18,7 @@ function escapeString(str) {
   if (typeof str !== "string") return str;
 
   return str
-    .replace(/&/g, "&amp;")
+    //.replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")

--- a/freeroam-extended/client/html/app.js
+++ b/freeroam-extended/client/html/app.js
@@ -26,8 +26,6 @@ function escapeString(str) {
 }
 
 function colorify(text) {
-  text = escapeString(text);
-
   let matches = [];
   let m = null;
   let curPos = 0;
@@ -235,8 +233,8 @@ function setVoiceConnectionState(state) {
   el.textContent = stateText
 }
 
-alt.on("addString", (text) => addString(colorify(text)));
-alt.on("addMessage", (name, text) => addString("<b>" + colorify(name) + ": </b>" + colorify(text)));
+alt.on("addString", (text) => addString(colorify(escapeString(text))));
+alt.on("addMessage", (name, text) => addString("<b>" + colorify(escapeString(name)) + ": </b>" + colorify(escapeString(text))));
 alt.on("openChat", openChat);
 alt.on("closeChat", closeChat);
 alt.on("updatePlayersOnline", updatePlayersOnline);


### PR DESCRIPTION
Currently, `"hello"` would be escaped to `&quot;hello&quot;` but not the actual string representation it should be

Closes https://github.com/altmp/altv-example-resources/issues/37

(When merging, please Squash Merge it)